### PR TITLE
Create admin panel skeleton

### DIFF
--- a/admin.jsx
+++ b/admin.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { AdminProvider } from './components/AdminContext';
+import AdminApp from './components/AdminApp';
+
+export default function Admin() {
+  return (
+    <AdminProvider>
+      <AdminApp />
+    </AdminProvider>
+  );
+}

--- a/components/AdminApp.jsx
+++ b/components/AdminApp.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import AdminNavigation from './AdminNavigation';
+import Footer from './Footer';
+import AdminDashboard from './AdminDashboard';
+import AdminUsers from './AdminUsers';
+import AdminSettings from './AdminSettings';
+import { useAdmin } from './AdminContext';
+
+const AdminApp = () => {
+  const { currentPage } = useAdmin();
+
+  const renderPage = () => {
+    switch (currentPage) {
+      case 'dashboard':
+        return <AdminDashboard />;
+      case 'users':
+        return <AdminUsers />;
+      case 'settings':
+        return <AdminSettings />;
+      default:
+        return <AdminDashboard />;
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-white">
+      <AdminNavigation />
+      <main>{renderPage()}</main>
+      <Footer />
+    </div>
+  );
+};
+
+export default AdminApp;

--- a/components/AdminContext.js
+++ b/components/AdminContext.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+export const AdminContext = React.createContext();
+
+export const useAdmin = () => {
+  const context = React.useContext(AdminContext);
+  if (!context) {
+    throw new Error('useAdmin must be used within AdminProvider');
+  }
+  return context;
+};
+
+export const AdminProvider = ({ children }) => {
+  const [currentPage, setCurrentPage] = useState('dashboard');
+  const [adminUser, setAdminUser] = useState(null);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  const value = {
+    currentPage,
+    setCurrentPage,
+    adminUser,
+    setAdminUser,
+    isAuthenticated,
+    setIsAuthenticated,
+  };
+
+  return (
+    <AdminContext.Provider value={value}>{children}</AdminContext.Provider>
+  );
+};

--- a/components/AdminDashboard.jsx
+++ b/components/AdminDashboard.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const AdminDashboard = () => {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      <p className="text-gray-700">Bienvenue sur le panneau d'administration.</p>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/components/AdminNavigation.jsx
+++ b/components/AdminNavigation.jsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { Menu, X, Home, Users, Settings } from 'lucide-react';
+import { useAdmin } from './AdminContext';
+
+const AdminNavigation = () => {
+  const { currentPage, setCurrentPage } = useAdmin();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const menuItems = [
+    { id: 'dashboard', label: 'Dashboard', icon: <Home className="w-4 h-4" /> },
+    { id: 'users', label: 'Utilisateurs', icon: <Users className="w-4 h-4" /> },
+    { id: 'settings', label: 'Param\u00e8tres', icon: <Settings className="w-4 h-4" /> },
+  ];
+
+  return (
+    <header className="bg-white shadow sticky top-0 z-50">
+      <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          <div className="flex items-center">
+            <button onClick={() => setCurrentPage('dashboard')} className="text-xl font-bold text-purple-600">
+              Admin
+            </button>
+          </div>
+          <div className="hidden md:block">
+            <div className="ml-10 flex items-baseline space-x-4">
+              {menuItems.map((item) => (
+                <button
+                  key={item.id}
+                  onClick={() => setCurrentPage(item.id)}
+                  className={`px-3 py-2 text-sm font-medium transition-colors flex items-center ${
+                    currentPage === item.id ? 'text-purple-600 bg-purple-50' : 'text-gray-900 hover:text-purple-600'
+                  }`}
+                >
+                  {item.icon}
+                  <span className="ml-2">{item.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="md:hidden">
+            <button onClick={() => setIsMenuOpen(!isMenuOpen)} className="text-gray-500 hover:text-gray-600">
+              {isMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+            </button>
+          </div>
+        </div>
+        {isMenuOpen && (
+          <div className="md:hidden">
+            <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t">
+              {menuItems.map((item) => (
+                <button
+                  key={item.id}
+                  onClick={() => {
+                    setCurrentPage(item.id);
+                    setIsMenuOpen(false);
+                  }}
+                  className="flex items-center w-full px-3 py-2 text-base font-medium text-gray-900 hover:text-purple-600"
+                >
+                  {item.icon}
+                  <span className="ml-2">{item.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </nav>
+    </header>
+  );
+};
+
+export default AdminNavigation;

--- a/components/AdminSettings.jsx
+++ b/components/AdminSettings.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const AdminSettings = () => {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Param\u00e8tres</h1>
+      <p className="text-gray-700">Configuration du panneau d'administration...</p>
+    </div>
+  );
+};
+
+export default AdminSettings;

--- a/components/AdminUsers.jsx
+++ b/components/AdminUsers.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const AdminUsers = () => {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Gestion des utilisateurs</h1>
+      <p className="text-gray-700">Liste des utilisateurs...</p>
+    </div>
+  );
+};
+
+export default AdminUsers;


### PR DESCRIPTION
## Summary
- add AdminContext provider for admin pages
- build AdminApp with dashboard, users and settings pages
- add AdminNavigation component
- update admin.jsx to render the AdminApp

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685488449b2c8323a6c2a85715ec2762