### PR TITLE
Fix missing dotenv module in backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "mysql2": "^3.4.2",
     "swagger-ui-express": "^4.6.2",
     "swagger-jsdoc": "^6.2.8",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- add `dotenv` dependency for Node.js backend

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_685562efac388323a59f785d8d3e84aa