### PR TITLE
Fix MySQL startup loop

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,5 @@
 DB_HOST=localhost
 DB_USER=root
-DB_PASSWORD=secret
+DB_PASSWORD=root
 DB_NAME=charisma_move
 PORT=3001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: charisma_move
-      MYSQL_USER: root
-      MYSQL_PASSWORD: root
     volumes:
       - db-data:/var/lib/mysql
     ports:


### PR DESCRIPTION
## Summary
- remove invalid `MYSQL_USER`/`MYSQL_PASSWORD` values from `docker-compose.yml`
- adjust example env file to use the default root password

## Testing
- `node --version`
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685563e9b1bc8323a78a664b14afabaa