### PR TITLE
Add frontend service in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,5 +24,16 @@ services:
       - "3001:3001"
     depends_on:
       - db
+  frontend:
+    image: node:18
+    container_name: charisma-frontend
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: npm run dev -- --host 0.0.0.0 --port 3000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
 volumes:
   db-data:


### PR DESCRIPTION
## Summary
- add a node-based frontend service in `docker-compose.yml`

## Testing
- `npm test` *(fails: Missing script)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855669c0c148323954a7957bd3ed6f0