### PR TITLE
Fix frontend startup in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,6 @@ You can launch a full development stack with Docker. Ensure Docker and Docker Co
 docker-compose up --build
 ```
 
-This will start a MySQL instance and the backend on port `3001`.
+This will start a MySQL instance and the backend on port `3001`. The frontend
+container installs its dependencies automatically and serves the React app on
+port `3000`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     working_dir: /app
     volumes:
       - .:/app
-    command: npm run dev -- --host 0.0.0.0 --port 3000
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 3000"
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
## Summary
- install frontend dependencies automatically in `docker-compose.yml`
- document updated Compose setup

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556815ce5c832383dc4df70d9b9a6e