### PR TITLE
Implement basic user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,16 @@ This project contains a React application and a simple Node.js backend. The back
 
 2. Copy `.env.example` to `.env` and adjust credentials to match your MySQL instance.
 
-3. Create a table for demo data:
+3. Create tables for demo data and users:
 
    ```sql
+   CREATE TABLE users (
+       id INT AUTO_INCREMENT PRIMARY KEY,
+       name VARCHAR(255) NOT NULL,
+       email VARCHAR(255) NOT NULL UNIQUE,
+       password VARCHAR(255) NOT NULL
+   );
+
    CREATE TABLE items (
        id INT AUTO_INCREMENT PRIMARY KEY,
        name VARCHAR(255) NOT NULL
@@ -31,6 +38,14 @@ This project contains a React application and a simple Node.js backend. The back
    ```
 
    The API will be available on `http://localhost:3001` and documentation on `http://localhost:3001/api-docs`.
+
+### User API
+
+The backend now exposes simple authentication endpoints:
+
+* `POST /api/users/register` – create a user. Body fields: `name`, `email`, `password`.
+* `POST /api/users/login` – obtain a JWT token. Body fields: `email`, `password`.
+* `GET /api/users/:id` – retrieve a user profile (requires `Authorization: Bearer <token>`).
 
 ## React usage
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,6 +3,8 @@ const mysql = require('mysql2/promise');
 const swaggerUi = require('swagger-ui-express');
 const swaggerJsdoc = require('swagger-jsdoc');
 const cors = require('cors');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
 require('dotenv').config();
 
 const app = express();
@@ -16,6 +18,21 @@ const pool = mysql.createPool({
   database: process.env.DB_NAME || 'charisma_move',
 });
 
+async function init() {
+  await pool.query(`CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL
+  )`);
+  await pool.query(`CREATE TABLE IF NOT EXISTS items (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+  )`);
+}
+
+init();
+
 async function getItems() {
   const [rows] = await pool.query('SELECT id, name FROM items');
   return rows;
@@ -24,6 +41,24 @@ async function getItems() {
 async function addItem(name) {
   const [result] = await pool.query('INSERT INTO items (name) VALUES (?)', [name]);
   return { id: result.insertId, name };
+}
+
+async function createUser(name, email, password) {
+  const [result] = await pool.query(
+    'INSERT INTO users (name, email, password) VALUES (?, ?, ?)',
+    [name, email, password]
+  );
+  return { id: result.insertId, name, email };
+}
+
+async function findUserByEmail(email) {
+  const [rows] = await pool.query('SELECT * FROM users WHERE email = ?', [email]);
+  return rows[0];
+}
+
+async function getUserById(id) {
+  const [rows] = await pool.query('SELECT id, name, email FROM users WHERE id = ?', [id]);
+  return rows[0];
 }
 
 app.get('/api/items', async (req, res) => {
@@ -46,12 +81,84 @@ app.post('/api/items', async (req, res) => {
   }
 });
 
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+  jwt.verify(token, process.env.JWT_SECRET || 'secret', (err, user) => {
+    if (err) return res.status(403).json({ error: 'Invalid token' });
+    req.user = user;
+    next();
+  });
+}
+
+app.post('/api/users/register', async (req, res) => {
+  const { name, email, password } = req.body;
+  if (!name || !email || !password) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  try {
+    const existing = await findUserByEmail(email);
+    if (existing) {
+      return res.status(409).json({ error: 'Email already in use' });
+    }
+    const hash = await bcrypt.hash(password, 10);
+    const user = await createUser(name, email, hash);
+    res.status(201).json(user);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+app.post('/api/users/login', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  try {
+    const user = await findUserByEmail(email);
+    if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) return res.status(401).json({ error: 'Invalid credentials' });
+    const token = jwt.sign({ id: user.id }, process.env.JWT_SECRET || 'secret', {
+      expiresIn: '1h',
+    });
+    res.json({ token, user: { id: user.id, name: user.name, email: user.email } });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+app.get('/api/users/:id', authenticateToken, async (req, res) => {
+  try {
+    if (parseInt(req.params.id, 10) !== req.user.id) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    const user = await getUserById(req.user.id);
+    res.json(user);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
 const options = {
   definition: {
     openapi: '3.0.0',
     info: {
       title: 'CharismaMove API',
       version: '1.0.0',
+    },
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
     },
   },
   apis: ['./index.js'],
@@ -81,6 +188,71 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(specs));
  *     responses:
  *       201:
  *         description: Item created
+ */
+
+/**
+ * @swagger
+ * /api/users/register:
+ *   post:
+ *     summary: Register a new user
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               email:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: User created
+ *       409:
+ *         description: Email already in use
+ *
+ * /api/users/login:
+ *   post:
+ *     summary: Login a user
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Authenticated user with token
+ *       401:
+ *         description: Invalid credentials
+ */
+
+/**
+ * @swagger
+ * /api/users/{id}:
+ *   get:
+ *     summary: Get user profile
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: User profile
+ *       401:
+ *         description: Unauthorized
  */
 
 const PORT = process.env.PORT || 3001;

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,8 @@
     "swagger-ui-express": "^4.6.2",
     "swagger-jsdoc": "^6.2.8",
     "cors": "^2.8.5",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.1"
   }
 }

--- a/components/CharismaMoveApp.jsx
+++ b/components/CharismaMoveApp.jsx
@@ -4,6 +4,9 @@ import Footer from './Footer';
 import HomePage from './HomePage';
 const SearchResultsPage = lazy(() => import('./SearchResultsPage'));
 const AboutPage = lazy(() => import('./AboutPage'));
+const LoginPage = lazy(() => import('./LoginPage'));
+const RegisterPage = lazy(() => import('./RegisterPage'));
+const ProfilePage = lazy(() => import('./ProfilePage'));
 import { useApp } from './context.jsx';
 
 const CharismaMoveApp = () => {
@@ -17,6 +20,12 @@ const CharismaMoveApp = () => {
         return <SearchResultsPage />;
       case 'about':
         return <AboutPage />;
+      case 'login':
+        return <LoginPage />;
+      case 'register':
+        return <RegisterPage />;
+      case 'profile':
+        return <ProfilePage />;
       default:
         return <HomePage />;
     }

--- a/components/LoginPage.jsx
+++ b/components/LoginPage.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { useApp } from './context.jsx';
+
+export default function LoginPage() {
+  const { setCurrentPage, setUser, setIsAuthenticated, setToken } = useApp();
+  const [form, setForm] = useState({ email: '', password: '' });
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await fetch('/api/users/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error('Authentication failed');
+      const data = await res.json();
+      setUser(data.user);
+      setToken(data.token);
+      setIsAuthenticated(true);
+      setCurrentPage('profile');
+    } catch (err) {
+      setError('Email ou mot de passe invalide');
+    }
+  };
+
+  return (
+    <div className="p-8 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Connexion</h1>
+      {error && <p className="text-red-600 mb-2">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="email"
+          placeholder="Email"
+          value={form.email}
+          onChange={(e) => setForm({ ...form, email: e.target.value })}
+          className="w-full border px-3 py-2 rounded"
+        />
+        <input
+          type="password"
+          placeholder="Mot de passe"
+          value={form.password}
+          onChange={(e) => setForm({ ...form, password: e.target.value })}
+          className="w-full border px-3 py-2 rounded"
+        />
+        <button type="submit" className="bg-purple-600 text-white px-4 py-2 rounded">
+          Se connecter
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/components/Navigation.jsx
+++ b/components/Navigation.jsx
@@ -3,7 +3,7 @@ import { Car, Home, Search, BookOpen, Heart, Menu, X } from 'lucide-react';
 import { useApp } from './context.jsx';
 
 const Navigation = () => {
-  const { currentPage, setCurrentPage } = useApp();
+  const { currentPage, setCurrentPage, isAuthenticated } = useApp();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const menuItems = [
@@ -47,15 +47,23 @@ const Navigation = () => {
 
           {/* Auth Buttons */}
           <div className="hidden md:flex items-center space-x-4">
-            <button onClick={() => setCurrentPage('login')} className="text-purple-600 hover:text-purple-800 font-medium">
-              Se connecter
-            </button>
-            <button
-              onClick={() => setCurrentPage('register')}
-              className="bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-2 rounded-full font-medium hover:from-purple-700 hover:to-pink-700 transition-all transform hover:scale-105"
-            >
-              S'inscrire
-            </button>
+            {isAuthenticated ? (
+              <button onClick={() => setCurrentPage('profile')} className="text-purple-600 hover:text-purple-800 font-medium">
+                Mon profil
+              </button>
+            ) : (
+              <>
+                <button onClick={() => setCurrentPage('login')} className="text-purple-600 hover:text-purple-800 font-medium">
+                  Se connecter
+                </button>
+                <button
+                  onClick={() => setCurrentPage('register')}
+                  className="bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-2 rounded-full font-medium hover:from-purple-700 hover:to-pink-700 transition-all transform hover:scale-105"
+                >
+                  S'inscrire
+                </button>
+              </>
+            )}
           </div>
 
           {/* Mobile menu button */}
@@ -83,6 +91,38 @@ const Navigation = () => {
                   <span className="ml-2">{item.label}</span>
                 </button>
               ))}
+              {isAuthenticated ? (
+                <button
+                  onClick={() => {
+                    setCurrentPage('profile');
+                    setIsMenuOpen(false);
+                  }}
+                  className="flex items-center w-full px-3 py-2 text-base font-medium text-gray-900 hover:text-purple-600"
+                >
+                  Mon profil
+                </button>
+              ) : (
+                <>
+                  <button
+                    onClick={() => {
+                      setCurrentPage('login');
+                      setIsMenuOpen(false);
+                    }}
+                    className="flex items-center w-full px-3 py-2 text-base font-medium text-gray-900 hover:text-purple-600"
+                  >
+                    Se connecter
+                  </button>
+                  <button
+                    onClick={() => {
+                      setCurrentPage('register');
+                      setIsMenuOpen(false);
+                    }}
+                    className="flex items-center w-full px-3 py-2 text-base font-medium text-gray-900 hover:text-purple-600"
+                  >
+                    S'inscrire
+                  </button>
+                </>
+              )}
             </div>
           </div>
         )}

--- a/components/ProfilePage.jsx
+++ b/components/ProfilePage.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { useApp } from './context.jsx';
+
+export default function ProfilePage() {
+  const { user, token, setCurrentPage, setIsAuthenticated, setUser, setToken } = useApp();
+  const [profile, setProfile] = useState(null);
+
+  useEffect(() => {
+    if (!token || !user) return;
+    fetch(`/api/users/${user.id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setProfile(data));
+  }, [token, user]);
+
+  const logout = () => {
+    setIsAuthenticated(false);
+    setUser(null);
+    setToken(null);
+    setCurrentPage('home');
+  };
+
+  if (!profile) return <div className="p-8">Chargement...</div>;
+
+  return (
+    <div className="p-8 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Profil</h1>
+      <p className="mb-2"><strong>Nom:</strong> {profile.name}</p>
+      <p className="mb-4"><strong>Email:</strong> {profile.email}</p>
+      <button onClick={logout} className="text-purple-600">Se déconnecter</button>
+    </div>
+  );
+}

--- a/components/RegisterPage.jsx
+++ b/components/RegisterPage.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { useApp } from './context.jsx';
+
+export default function RegisterPage() {
+  const { setCurrentPage } = useApp();
+  const [form, setForm] = useState({ name: '', email: '', password: '' });
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await fetch('/api/users/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (res.status === 409) {
+        setError('Email déjà utilisé');
+        return;
+      }
+      if (!res.ok) throw new Error('Error');
+      setSuccess(true);
+    } catch (err) {
+      setError("Une erreur s'est produite");
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="p-8 text-center">
+        <h1 className="text-2xl font-bold mb-4">Inscription réussie !</h1>
+        <button onClick={() => setCurrentPage('login')} className="text-purple-600">Se connecter</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Inscription</h1>
+      {error && <p className="text-red-600 mb-2">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          placeholder="Nom"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+          className="w-full border px-3 py-2 rounded"
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          value={form.email}
+          onChange={(e) => setForm({ ...form, email: e.target.value })}
+          className="w-full border px-3 py-2 rounded"
+        />
+        <input
+          type="password"
+          placeholder="Mot de passe"
+          value={form.password}
+          onChange={(e) => setForm({ ...form, password: e.target.value })}
+          className="w-full border px-3 py-2 rounded"
+        />
+        <button type="submit" className="bg-purple-600 text-white px-4 py-2 rounded">
+          S'inscrire
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/components/context.jsx
+++ b/components/context.jsx
@@ -14,6 +14,7 @@ export const AppProvider = ({ children }) => {
   const [currentPage, setCurrentPage] = useState('home');
   const [user, setUser] = useState(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [token, setToken] = useState(null);
   const [searchResults, setSearchResults] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -24,6 +25,8 @@ export const AppProvider = ({ children }) => {
     setUser,
     isAuthenticated,
     setIsAuthenticated,
+    token,
+    setToken,
     searchResults,
     setSearchResults,
     isLoading,


### PR DESCRIPTION
## Summary
- create `users` table instructions and add endpoints documentation
- add bcryptjs and jsonwebtoken to backend
- implement user registration, login, and profile endpoints
- add authentication pages in React and context updates
- show profile links in navigation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855ce33aaf08323a21fddeba950f764