### PR TITLE
Fix login/registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,12 @@ The backend now exposes simple authentication endpoints. A default administrator
 
 The React `AboutPage` now includes a small example component (`DataList`) that fetches and adds items using the backend API.
 
-Run your favorite React bundler to serve the frontend and ensure requests are proxied to the Node server.
+Install the frontend dependencies in the project root and start the Vite dev server. The configuration proxies any `/api` calls to the backend on port `3001` so that registration and login work during development.
+
+```bash
+npm install
+npm run dev
+```
 
 ## Docker usage
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001',
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- configure vite to proxy backend requests
- document the dev server setup in the README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d528f2e48323840cf09ff1f23908