### PR TITLE
Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project contains a React application and a simple Node.js backend. The backend stores data in a MySQL database and exposes REST APIs documented with Swagger. The React interface demonstrates how to consume these APIs.
 
+## Quick setup
+
+Run `npm run setup` from the project root to install both frontend and backend dependencies in one step. This installs packages in the `backend` folder as well.
+
 ## Backend setup
 
 1. Navigate to the `backend` directory and install dependencies:
@@ -55,7 +59,7 @@ The backend now exposes simple authentication endpoints. A default administrator
 
 The React `AboutPage` now includes a small example component (`DataList`) that fetches and adds items using the backend API.
 
-Install the frontend dependencies in the project root and start the Vite dev server. The configuration proxies any `/api` calls to the backend on port `3001` so that registration and login work during development.
+Install the frontend dependencies (and ensure the backend ones are installed via `npm run setup`) in the project root and start the Vite dev server. The configuration proxies any `/api` calls to the backend on port `3001` so that registration and login work during development.
 
 ```bash
 npm install

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "setup": "npm install && cd backend && npm install"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- add `setup` npm script that installs backend dependencies
- update README to mention quick setup and reference the script in dev instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855d6aefce083238f7338d4493bc89e