### PR TITLE
Improve login error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,10 @@ docker-compose up --build
 This will start a MySQL instance and the backend on port `3001`. The frontend
 container installs its dependencies automatically and serves the React app on
 port `3000`.
+
+## Troubleshooting
+
+If the login form displays **"Email ou mot de passe invalide"** even though you
+are using the correct credentials, verify that the backend server is running on
+port `3001`. A network or server error will result in the same message on the
+frontend.

--- a/components/LoginPage.jsx
+++ b/components/LoginPage.jsx
@@ -15,14 +15,20 @@ export default function LoginPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(form),
       });
-      if (!res.ok) throw new Error('Authentication failed');
-      const data = await res.json();
-      setUser(data.user);
-      setToken(data.token);
-      setIsAuthenticated(true);
-      setCurrentPage('profile');
+
+      if (res.ok) {
+        const data = await res.json();
+        setUser(data.user);
+        setToken(data.token);
+        setIsAuthenticated(true);
+        setCurrentPage('profile');
+      } else if (res.status === 401) {
+        setError('Email ou mot de passe invalide');
+      } else {
+        setError("Erreur lors de la connexion. Veuillez réessayer plus tard.");
+      }
     } catch (err) {
-      setError('Email ou mot de passe invalide');
+      setError("Impossible de contacter le serveur");
     }
   };
 


### PR DESCRIPTION
## Summary
- update the login page to handle network errors separately and show clearer error messages
- add troubleshooting notes about the login form to the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855d96b04548323b0e41ee52569e011