### PR TITLE
Add phpMyAdmin to Docker compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ This will start a MySQL instance and the backend on port `3001`. The frontend
 container installs its dependencies automatically and serves the React app on
 port `3000`.
 
+phpMyAdmin is also available at [http://localhost:8080](http://localhost:8080)
+to manage the MySQL database. Use `root`/`root` to sign in.
+
 ## Troubleshooting
 
 If the login form displays **"Email ou mot de passe invalide"** even though you

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,5 +35,15 @@ services:
       - "3000:3000"
     depends_on:
       - backend
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    restart: unless-stopped
+    environment:
+      PMA_HOST: db
+      PMA_PORT: 3306
+    ports:
+      - "8080:80"
+    depends_on:
+      - db
 volumes:
   db-data:


### PR DESCRIPTION
## Summary
- include phpMyAdmin service in `docker-compose.yml`
- document phpMyAdmin access in the README

## Testing
- `docker-compose config` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855dbaea1a483238041a26033e5f232