### PR TITLE
Fix DB initialization and phpMyAdmin port

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This will start a MySQL instance and the backend on port `3001`. The frontend
 container installs its dependencies automatically and serves the React app on
 port `3000`.
 
-phpMyAdmin is also available at [http://localhost:8080](http://localhost:8080)
+phpMyAdmin is also available at [http://localhost:8081](http://localhost:8081)
 to manage the MySQL database. Use `root`/`root` to sign in.
 
 ## Troubleshooting

--- a/backend/index.js
+++ b/backend/index.js
@@ -31,6 +31,19 @@ async function init() {
     name VARCHAR(255) NOT NULL
   )`);
 
+  // Add is_admin column for existing installations
+  const [cols] = await pool.query(
+    `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+     WHERE TABLE_SCHEMA = DATABASE()
+       AND TABLE_NAME = 'users'
+       AND COLUMN_NAME = 'is_admin'`
+  );
+  if (cols.length === 0) {
+    await pool.query(
+      'ALTER TABLE users ADD COLUMN is_admin BOOLEAN DEFAULT FALSE'
+    );
+  }
+
   // Create a default admin if none exists
   const [rows] = await pool.query('SELECT COUNT(*) as count FROM users WHERE is_admin = TRUE');
   if (rows[0].count === 0) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       PMA_HOST: db
       PMA_PORT: 3306
     ports:
-      - "8080:80"
+      - "8081:80"
     depends_on:
       - db
 volumes:


### PR DESCRIPTION
## Summary
- ensure the `is_admin` column exists when the backend starts
- move phpMyAdmin to port 8081 to avoid host conflicts
- update README with new phpMyAdmin port

## Testing
- `node -c backend/index.js`

------
https://chatgpt.com/codex/tasks/task_e_6855e3063f34832397b088388fac3637