### PR TITLE
Add troubleshooting note for port conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,11 @@ If the login form displays **"Email ou mot de passe invalide"** even though you
 are using the correct credentials, verify that the backend server is running on
 port `3001`. A network or server error will result in the same message on the
 frontend.
+
+If `npm start` prints an **"EADDRINUSE"** error, another process is already
+using port `3001`. Stop the existing process or run the backend on a different
+port:
+
+```bash
+PORT=3002 npm start
+```


### PR DESCRIPTION
## Summary
- note how to resolve EADDRINUSE on npm start by changing the port

## Testing
- `npm run setup` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6855eaf02d008323883d23ad4a0c5872