### PR TITLE
Fix docker proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ docker-compose up --build
 
 This will start a MySQL instance and the backend on port `3001`. The frontend
 container installs its dependencies automatically and serves the React app on
-port `3000`.
+port `3000`. The Vite dev server reads the `VITE_BACKEND_URL` environment
+variable to know where the API is located. In the provided `docker-compose.yml`
+this variable is set to `http://backend:3001` so the frontend can reach the
+backend container.
 
 phpMyAdmin is also available at [http://localhost:8081](http://localhost:8081)
 to manage the MySQL database. Use `root`/`root` to sign in.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 3000"
     ports:
       - "3000:3000"
+    environment:
+      - VITE_BACKEND_URL=http://backend:3001
     depends_on:
       - backend
   phpmyadmin:

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/api': 'http://localhost:3001',
+      '/api': process.env.VITE_BACKEND_URL || 'http://localhost:3001',
     },
   },
 });


### PR DESCRIPTION
## Summary
- let vite proxy use `$VITE_BACKEND_URL` with localhost fallback
- set `VITE_BACKEND_URL` for frontend container
- document docker proxy configuration in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e4ca7a7c8323936679e28eee02db