### PR TITLE
Add trip filtering by search criteria

### DIFF
--- a/components/HomePage.jsx
+++ b/components/HomePage.jsx
@@ -51,7 +51,7 @@ const STATS = [
 ];
 
 export default function HomePage() {
-  const { setCurrentPage } = useApp();
+  const { setCurrentPage, setSearchParams } = useApp();
   const [toast, setToast] = useState(null);
   const [form, setForm] = useState({
     depart: '',
@@ -67,6 +67,12 @@ export default function HomePage() {
       showToast('Veuillez remplir tous les champs obligatoires', 'error');
       return;
     }
+    setSearchParams({
+      depart: form.depart,
+      destination: form.destination,
+      date: form.date,
+      passengers: parseInt(form.passengers) || 1,
+    });
     showToast('Recherche en cours...');
     setTimeout(() => setCurrentPage('search-results'), 1000);
   };

--- a/components/SearchResultsPage.jsx
+++ b/components/SearchResultsPage.jsx
@@ -24,7 +24,19 @@ const MOCK_TRIPS = [
 ];
 
 const SearchResultsPage = () => {
-  const { setCurrentPage } = useApp();
+  const { setCurrentPage, searchParams } = useApp();
+
+  const filteredTrips = React.useMemo(() => {
+    if (!searchParams) return MOCK_TRIPS;
+    const depart = searchParams.depart.toLowerCase();
+    const destination = searchParams.destination.toLowerCase();
+    const passengers = searchParams.passengers || 1;
+    return MOCK_TRIPS.filter((t) =>
+      t.departure.city.toLowerCase().includes(depart) &&
+      t.arrival.city.toLowerCase().includes(destination) &&
+      t.seats >= passengers
+    ).sort((a, b) => b.driver.rating - a.driver.rating);
+  }, [searchParams]);
 
   return (
     <div className="min-h-screen bg-gray-50 py-8">
@@ -35,11 +47,17 @@ const SearchResultsPage = () => {
             Retour à la recherche
           </button>
           <h1 className="text-3xl font-bold text-gray-900 mb-2">Trajets disponibles</h1>
-          <p className="text-gray-600">Paris → Lyon • {MOCK_TRIPS.length} trajet(s) trouvé(s)</p>
+          {searchParams ? (
+            <p className="text-gray-600">
+              {searchParams.depart} → {searchParams.destination} • {filteredTrips.length} trajet(s) trouvé(s)
+            </p>
+          ) : (
+            <p className="text-gray-600">{filteredTrips.length} trajet(s) trouvé(s)</p>
+          )}
         </div>
 
         <div className="space-y-6">
-          {MOCK_TRIPS.map((trip) => (
+          {filteredTrips.map((trip) => (
             <div key={trip.id} className="bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-shadow">
               <div className="flex flex-col md:flex-row md:items-center justify-between">
                 <div className="flex-1">

--- a/components/context.jsx
+++ b/components/context.jsx
@@ -26,6 +26,7 @@ export const AppProvider = ({ children }) => {
   };
   const [searchResults, setSearchResults] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [searchParams, setSearchParams] = useState(null);
 
   const value = {
     currentPage,
@@ -39,7 +40,9 @@ export const AppProvider = ({ children }) => {
     searchResults,
     setSearchResults,
     isLoading,
-    setIsLoading
+    setIsLoading,
+    searchParams,
+    setSearchParams
   };
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>;


### PR DESCRIPTION
## Summary
- persist search params in context
- set search params from the home page search form
- filter and sort search results with a simple matching algorithm

## Testing
- `npm run build` *(fails: vite not found)*
- `node backend/index.js` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6856f31305bc8323bc674111c4414d0d