### PR TITLE
Add booking confirmation notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ JWT_SECRET=your_jwt_secret
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=admin123
 ADMIN_NAME=Admin
+ADMIN_PHONE=
+SENDGRID_API_KEY=
+FROM_EMAIL=
+TEXTBELT_KEY=textbelt

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Run `npm run setup` from the project root to install both frontend and backend d
 
 2. Copy `.env.example` to `.env` and adjust credentials to match your MySQL instance. You can also set the initial administrator credentials here using `ADMIN_EMAIL` and `ADMIN_PASSWORD`.
 
-3. Create tables for demo data and users (the `users` table now includes an `is_admin` column to flag administrators):
+3. Create tables for demo data and users (the `users` table now includes `is_admin` and `phone` columns):
 
    ```sql
    CREATE TABLE users (
@@ -27,6 +27,7 @@ Run `npm run setup` from the project root to install both frontend and backend d
        name VARCHAR(255) NOT NULL,
        email VARCHAR(255) NOT NULL UNIQUE,
        password VARCHAR(255) NOT NULL,
+       phone VARCHAR(20),
        is_admin BOOLEAN DEFAULT FALSE
    );
 
@@ -47,13 +48,15 @@ Run `npm run setup` from the project root to install both frontend and backend d
 ### User API
 
 The backend now exposes simple authentication endpoints. A default administrator account is created on first run using the `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables (defaults are `admin@example.com`/`admin123`).
+Set `SENDGRID_API_KEY` and `FROM_EMAIL` to enable email notifications. `TEXTBELT_KEY` can be provided for SMS sending (defaults to the free `textbelt` key).
 
 #### Endpoints
 
-* `POST /api/users/register` – create a user. Body fields: `name`, `email`, `password`.
+* `POST /api/users/register` – create a user. Body fields: `name`, `email`, `password`, `phone`.
 * `POST /api/users/login` – obtain a JWT token. Body fields: `email`, `password`.
 * `POST /api/admin/login` – login as administrator. Body fields: `email`, `password`.
 * `GET /api/users/:id` – retrieve a user profile (requires `Authorization: Bearer <token>`).
+* `POST /api/bookings/{id}/confirm` – confirm a booking and trigger email/SMS notifications.
 
 ## React usage
 

--- a/components/RegisterPage.jsx
+++ b/components/RegisterPage.jsx
@@ -3,7 +3,7 @@ import { useApp } from './context.jsx';
 
 export default function RegisterPage() {
   const { setCurrentPage } = useApp();
-  const [form, setForm] = useState({ name: '', email: '', password: '' });
+  const [form, setForm] = useState({ name: '', email: '', password: '', phone: '' });
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
 
@@ -60,6 +60,13 @@ export default function RegisterPage() {
           placeholder="Mot de passe"
           value={form.password}
           onChange={(e) => setForm({ ...form, password: e.target.value })}
+          className="w-full border px-3 py-2 rounded"
+        />
+        <input
+          type="tel"
+          placeholder="Téléphone"
+          value={form.phone}
+          onChange={(e) => setForm({ ...form, phone: e.target.value })}
           className="w-full border px-3 py-2 rounded"
         />
         <button type="submit" className="bg-purple-600 text-white px-4 py-2 rounded">


### PR DESCRIPTION
## Summary
- add phone/email environment variables and update docs
- extend `users` table with a phone column
- support phone in registration form and API
- implement email and SMS notifications when confirming bookings

## Testing
- `node -c backend/index.js`
- *(Node syntax check for RegisterPage.jsx failed due to unknown extension)*

------
https://chatgpt.com/codex/tasks/task_e_6856f5a30c7083238128e8ec90c9e7e2