### PR TITLE
Require profile info before booking

### DIFF
--- a/components/BookingPage.jsx
+++ b/components/BookingPage.jsx
@@ -1,11 +1,65 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ArrowRight } from 'lucide-react';
 import { useApp } from './context.jsx';
 
 export default function BookingPage() {
-  const { setCurrentPage, token } = useApp();
+  const { setCurrentPage, token, user } = useApp();
   const [seats, setSeats] = useState(1);
+  const [profile, setProfile] = useState(null);
+  const [info, setInfo] = useState({ name: '', first_name: '', phone: '', gender: '' });
+  const [needsInfo, setNeedsInfo] = useState(false);
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      if (!token || !user) return;
+      try {
+        const res = await fetch(`/api/users/${user.id}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setProfile(data);
+          setInfo({
+            name: data.name || '',
+            first_name: data.first_name || '',
+            phone: data.phone || '',
+            gender: data.gender || '',
+          });
+          if (!data.phone || !data.gender || !data.first_name || !data.name) {
+            setNeedsInfo(true);
+          }
+        }
+      } catch {
+        /* ignore */
+      }
+    };
+    fetchProfile();
+  }, [token, user]);
+
+  const handleProfileSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await fetch(`/api/users/${user.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(info),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setProfile(data);
+        setNeedsInfo(false);
+      } else {
+        alert('Erreur lors de la mise à jour du profil');
+      }
+    } catch {
+      alert('Erreur lors de la mise à jour du profil');
+    }
+  };
   const handleSubmit = async () => {
+    if (needsInfo) return;
     try {
       const res = await fetch('/api/bookings', {
         method: 'POST',
@@ -38,6 +92,45 @@ export default function BookingPage() {
         <ArrowRight className="w-4 h-4 mr-2 rotate-180" />
         Retour
       </button>
+      {needsInfo && (
+        <form onSubmit={handleProfileSubmit} className="bg-white rounded-xl shadow-lg p-6 space-y-4 mb-6">
+          <h2 className="font-semibold">Complétez votre profil</h2>
+          <input
+            type="text"
+            placeholder="Nom"
+            value={info.name}
+            onChange={(e) => setInfo({ ...info, name: e.target.value })}
+            className="w-full border px-3 py-2 rounded"
+          />
+          <input
+            type="text"
+            placeholder="Prénom"
+            value={info.first_name}
+            onChange={(e) => setInfo({ ...info, first_name: e.target.value })}
+            className="w-full border px-3 py-2 rounded"
+          />
+          <input
+            type="tel"
+            placeholder="Téléphone"
+            value={info.phone}
+            onChange={(e) => setInfo({ ...info, phone: e.target.value })}
+            className="w-full border px-3 py-2 rounded"
+          />
+          <select
+            value={info.gender}
+            onChange={(e) => setInfo({ ...info, gender: e.target.value })}
+            className="w-full border px-3 py-2 rounded"
+          >
+            <option value="">Genre</option>
+            <option value="M">Homme</option>
+            <option value="F">Femme</option>
+            <option value="O">Autre</option>
+          </select>
+          <button type="submit" className="w-full bg-purple-600 text-white py-2 rounded-lg">
+            Enregistrer
+          </button>
+        </form>
+      )
       <div className="bg-white rounded-xl shadow-lg p-6 space-y-4">
         <div>
           <label className="block text-sm font-medium mb-1">Nombre de places</label>

--- a/components/ProfilePage.jsx
+++ b/components/ProfilePage.jsx
@@ -27,6 +27,9 @@ export default function ProfilePage() {
     <div className="p-8 max-w-md mx-auto">
       <h1 className="text-2xl font-bold mb-4">Profil</h1>
       <p className="mb-2"><strong>Nom:</strong> {profile.name}</p>
+      <p className="mb-2"><strong>Prénom:</strong> {profile.first_name}</p>
+      <p className="mb-2"><strong>Téléphone:</strong> {profile.phone}</p>
+      <p className="mb-2"><strong>Genre:</strong> {profile.gender}</p>
       <p className="mb-4"><strong>Email:</strong> {profile.email}</p>
       <button onClick={logout} className="text-purple-600">Se déconnecter</button>
     </div>

--- a/components/RegisterPage.jsx
+++ b/components/RegisterPage.jsx
@@ -3,7 +3,7 @@ import { useApp } from './context.jsx';
 
 export default function RegisterPage() {
   const { setCurrentPage } = useApp();
-  const [form, setForm] = useState({ name: '', email: '', password: '', phone: '' });
+  const [form, setForm] = useState({ name: '', first_name: '', gender: '', email: '', password: '', phone: '' });
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
 
@@ -49,6 +49,13 @@ export default function RegisterPage() {
           className="w-full border px-3 py-2 rounded"
         />
         <input
+          type="text"
+          placeholder="Prénom"
+          value={form.first_name}
+          onChange={(e) => setForm({ ...form, first_name: e.target.value })}
+          className="w-full border px-3 py-2 rounded"
+        />
+        <input
           type="email"
           placeholder="Email"
           value={form.email}
@@ -62,6 +69,16 @@ export default function RegisterPage() {
           onChange={(e) => setForm({ ...form, password: e.target.value })}
           className="w-full border px-3 py-2 rounded"
         />
+        <select
+          value={form.gender}
+          onChange={(e) => setForm({ ...form, gender: e.target.value })}
+          className="w-full border px-3 py-2 rounded"
+        >
+          <option value="">Genre</option>
+          <option value="M">Homme</option>
+          <option value="F">Femme</option>
+          <option value="O">Autre</option>
+        </select>
         <input
           type="tel"
           placeholder="Téléphone"


### PR DESCRIPTION
## Summary
- add first name and gender columns and user update route in backend
- include profile update step in booking flow
- extend register and profile pages with new fields

## Testing
- `node --check backend/index.js`

------
https://chatgpt.com/codex/tasks/task_e_6856f7bdfc088323beff8052ccfc2300