### PR TITLE
Implement announcement publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Set `SENDGRID_API_KEY` and `FROM_EMAIL` to enable email notifications. `TEXTBELT
 * `GET /api/users/:id` – retrieve a user profile (requires `Authorization: Bearer <token>`).
 * `POST /api/bookings/{id}/confirm` – confirm a booking and trigger email/SMS notifications.
 
+### Announcements API
+
+Publishers can create trip announcements that other users may browse.
+
+* `POST /api/announcements` – publish a trip (requires authentication). Body fields: `departure`, `destination`, `datetime`, `seats`.
+* `GET /api/announcements` – list announcements. Optional query params: `departure`, `destination`, `seats`.
+
 ## React usage
 
 The React `AboutPage` now includes a small example component (`DataList`) that fetches, searches and adds items using the backend API. You can filter items by passing a `q` query parameter to `/api/items`.

--- a/components/PublishTripPage.jsx
+++ b/components/PublishTripPage.jsx
@@ -3,7 +3,7 @@ import { ArrowRight } from 'lucide-react';
 import { useApp } from './context.jsx';
 
 export default function PublishTripPage() {
-  const { setCurrentPage } = useApp();
+  const { setCurrentPage, token } = useApp();
   const [form, setForm] = useState({
     departure: '',
     destination: '',
@@ -13,16 +13,28 @@ export default function PublishTripPage() {
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     setError(null);
-    const { departure, destination, datetime } = form;
+    const { departure, destination, datetime, seats } = form;
     if (!departure || !destination || !datetime) {
       setError('Veuillez remplir tous les champs obligatoires');
       return;
     }
-    console.log('Publication de trajet:', form);
-    setSuccess(true);
+    try {
+      const res = await fetch('/api/announcements', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ departure, destination, datetime, seats }),
+      });
+      if (!res.ok) throw new Error();
+      setSuccess(true);
+    } catch {
+      setError("Erreur lors de l'enregistrement");
+    }
   };
 
   if (success) {


### PR DESCRIPTION
## Summary
- persist trip announcements in a new `announcements` table
- expose `/api/announcements` endpoints
- allow trip publishing from the UI
- document announcement endpoints

## Testing
- `npm test` *(fails: Missing script)*
- `cd backend && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685713938bac832398cd141cd0c3a8cf