### PR TITLE
Add admin login and logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ npm install
 npm run dev
 ```
 
+## Administration
+
+An administration interface is available for managing users. After starting the
+development server, open `admin.html` in your browser and sign in with the
+credentials defined by `ADMIN_EMAIL` and `ADMIN_PASSWORD` in your `.env` file.
+
 ## Docker usage
 
 You can launch a full development stack with Docker. Ensure Docker and Docker Compose are installed, then run:

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Charisma Move Admin</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/admin.jsx"></script>
+  </body>
+</html>

--- a/components/AdminApp.jsx
+++ b/components/AdminApp.jsx
@@ -5,9 +5,10 @@ import AdminDashboard from './AdminDashboard';
 import AdminUsers from './AdminUsers';
 import AdminSettings from './AdminSettings';
 import { useAdmin } from './AdminContext.jsx';
+import AdminLoginPage from './AdminLoginPage.jsx';
 
 const AdminApp = () => {
-  const { currentPage } = useAdmin();
+  const { currentPage, isAuthenticated } = useAdmin();
 
   const renderPage = () => {
     switch (currentPage) {
@@ -24,9 +25,15 @@ const AdminApp = () => {
 
   return (
     <div className="min-h-screen bg-white">
-      <AdminNavigation />
-      <main>{renderPage()}</main>
-      <Footer />
+      {isAuthenticated ? (
+        <>
+          <AdminNavigation />
+          <main>{renderPage()}</main>
+          <Footer />
+        </>
+      ) : (
+        <AdminLoginPage />
+      )}
     </div>
   );
 };

--- a/components/AdminContext.jsx
+++ b/components/AdminContext.jsx
@@ -14,6 +14,16 @@ export const AdminProvider = ({ children }) => {
   const [currentPage, setCurrentPage] = useState('dashboard');
   const [adminUser, setAdminUser] = useState(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [token, setTokenState] = useState(() => localStorage.getItem('adminToken'));
+
+  const setToken = (t) => {
+    if (t) {
+      localStorage.setItem('adminToken', t);
+    } else {
+      localStorage.removeItem('adminToken');
+    }
+    setTokenState(t);
+  };
 
   const value = {
     currentPage,
@@ -22,6 +32,8 @@ export const AdminProvider = ({ children }) => {
     setAdminUser,
     isAuthenticated,
     setIsAuthenticated,
+    token,
+    setToken,
   };
 
   return (

--- a/components/AdminLoginPage.jsx
+++ b/components/AdminLoginPage.jsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { useAdmin } from './AdminContext.jsx';
+
+export default function AdminLoginPage() {
+  const { setIsAuthenticated, setAdminUser, setToken } = useAdmin();
+  const [form, setForm] = useState({ email: '', password: '' });
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await fetch('/api/admin/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setAdminUser(data.admin);
+        setToken(data.token);
+        setIsAuthenticated(true);
+      } else if (res.status === 401) {
+        setError('Email ou mot de passe invalide');
+      } else {
+        setError("Erreur lors de la connexion. Veuillez r\u00e9essayer plus tard.");
+      }
+    } catch (err) {
+      setError("Impossible de contacter le serveur");
+    }
+  };
+
+  return (
+    <div className="p-8 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Connexion Admin</h1>
+      {error && <p className="text-red-600 mb-2">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="email"
+          placeholder="Email"
+          value={form.email}
+          onChange={(e) => setForm({ ...form, email: e.target.value })}
+          className="w-full border px-3 py-2 rounded"
+        />
+        <input
+          type="password"
+          placeholder="Mot de passe"
+          value={form.password}
+          onChange={(e) => setForm({ ...form, password: e.target.value })}
+          className="w-full border px-3 py-2 rounded"
+        />
+        <button type="submit" className="bg-purple-600 text-white px-4 py-2 rounded">
+          Se connecter
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/components/AdminNavigation.jsx
+++ b/components/AdminNavigation.jsx
@@ -1,16 +1,28 @@
 import React, { useState } from 'react';
-import { Menu, X, Home, Users, Settings } from 'lucide-react';
+import { Menu, X, Home, Users, Settings, LogOut } from 'lucide-react';
 import { useAdmin } from './AdminContext.jsx';
 
 const AdminNavigation = () => {
-  const { currentPage, setCurrentPage } = useAdmin();
+  const { currentPage, setCurrentPage, setIsAuthenticated, setAdminUser, setToken } = useAdmin();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const menuItems = [
     { id: 'dashboard', label: 'Dashboard', icon: <Home className="w-4 h-4" /> },
     { id: 'users', label: 'Utilisateurs', icon: <Users className="w-4 h-4" /> },
     { id: 'settings', label: 'Param\u00e8tres', icon: <Settings className="w-4 h-4" /> },
+    { id: 'logout', label: 'D\u00e9connexion', icon: <LogOut className="w-4 h-4" /> },
   ];
+
+  const handleClick = (id) => {
+    if (id === 'logout') {
+      setIsAuthenticated(false);
+      setAdminUser(null);
+      setToken(null);
+      setCurrentPage('dashboard');
+    } else {
+      setCurrentPage(id);
+    }
+  };
 
   return (
     <header className="bg-white shadow sticky top-0 z-50">
@@ -26,7 +38,7 @@ const AdminNavigation = () => {
               {menuItems.map((item) => (
                 <button
                   key={item.id}
-                  onClick={() => setCurrentPage(item.id)}
+                  onClick={() => handleClick(item.id)}
                   className={`px-3 py-2 text-sm font-medium transition-colors flex items-center ${
                     currentPage === item.id ? 'text-purple-600 bg-purple-50' : 'text-gray-900 hover:text-purple-600'
                   }`}
@@ -50,7 +62,7 @@ const AdminNavigation = () => {
                 <button
                   key={item.id}
                   onClick={() => {
-                    setCurrentPage(item.id);
+                    handleClick(item.id);
                     setIsMenuOpen(false);
                   }}
                   className="flex items-center w-full px-3 py-2 text-base font-medium text-gray-900 hover:text-purple-600"


### PR DESCRIPTION
## Summary
- add dedicated admin login page
- store admin auth token in context
- redirect unauthenticated admins to login
- include logout action in admin navigation
- provide admin entry HTML
- document admin panel usage

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685715384e488323a9d14321f95117a2