### PR TITLE
Fix login endpoint mismatch

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -570,6 +570,17 @@ app.get('/api/users/:id', authenticateToken, async (req, res) => {
   }
 });
 
+app.get('/api/auth/me', authenticateToken, async (req, res) => {
+  try {
+    const user = await getUserById(req.user.id);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    res.json({ user });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
 app.put('/api/users/:id', authenticateToken, async (req, res) => {
   try {
     if (parseInt(req.params.id, 10) !== req.user.id) {

--- a/components/context.jsx
+++ b/components/context.jsx
@@ -33,7 +33,7 @@ export const AppProvider = ({ children }) => {
     try {
       setIsLoading(true);
       setError(null);
-      const response = await fetch('/api/auth/login', {
+      const response = await fetch('/api/users/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password })


### PR DESCRIPTION
## Summary
- update front-end login request to use `/api/users/login`
- add missing `/api/auth/me` route in the backend for token verification

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cae44762483239c34b456c6369eda